### PR TITLE
Create constant XOUTPUT_DEVICE_ARGUMENT to control calibrate_mapping

### DIFF
--- a/huion-tablet-driver.py
+++ b/huion-tablet-driver.py
@@ -13,7 +13,10 @@ from time import gmtime, strftime, sleep
 import atexit
 
 MENU = {}
-XINPUT_DEVICE_KEYWORD = "Tablet Monitor Pen"
+XINPUT_DEVICE_KEYWORD = "Tablet Monitor Pen"  # your pen's name in the terminal output of xinput
+XOUTPUT_DEVICE_ARGUMENT = -1  # defaults to final active monitor in terminal output of xrandr
+                              # ... change to select specific monitor in xoutput_devices
+
 
 # -----------------------------------------------------------------------------
 class main():
@@ -316,8 +319,11 @@ def cleanup_multi_pointer():
 
 
 # -----------------------------------------------------------------------------
-def calibrate_mapping(xinput_device_keyword=XINPUT_DEVICE_KEYWORD):
-
+def calibrate_mapping(xinput_device_keyword=XINPUT_DEVICE_KEYWORD, xoutput_device_argument=XOUTPUT_DEVICE_ARGUMENT):
+    """
+    Maps tablet pen, specified by xinput_device_keyword, to a given monitor, specified by xoutput_device_argument.
+    If xoutput_device_argument=-1, the pen's bounds will calibrate to the last active monitor in xrandr.
+    """
     try:
         # Locate tablet pen device number
         xinput_device = os.popen("xinput | grep '%s' | cut -f 2" % xinput_device_keyword).read()
@@ -325,8 +331,8 @@ def calibrate_mapping(xinput_device_keyword=XINPUT_DEVICE_KEYWORD):
         
         # Locate output device name
         xoutput_devices = os.popen("xrandr --listactivemonitors | sort | cut -f 6 -d ' ' ").read()
-        xoutput_devices = list(filter(None, xoutput_devices.split('\n'))) # Assumes the first device is the main monitor and the second is the graphic monitor
-        xoutput_device = xoutput_devices[-1]
+        xoutput_devices = list(filter(None, xoutput_devices.split('\n')))  # lists all active monitors
+        xoutput_device = xoutput_devices[xoutput_device_argument]
         
         # Lenovo's defaults
         if xinput_device == '':


### PR DESCRIPTION
Introduces a constant so that users can specify their output monitor for calibrate_mapping(). 
This expands on the bug fix mentioned here https://github.com/joseluis/huion-linux-drivers/pull/53#discussion_r362628886